### PR TITLE
 Rework release leftovers gc algorithm

### DIFF
--- a/api/operator/v1alpha1/zz_generated.deepcopy.go
+++ b/api/operator/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	runtime "k8s.io/apimachinery/pkg/runtime"
 )
 

--- a/internal/controller/operator/instance/dapr_instance_controller.go
+++ b/internal/controller/operator/instance/dapr_instance_controller.go
@@ -78,6 +78,7 @@ func NewReconciler(ctx context.Context, manager ctrlRt.Manager, o helm.Options) 
 	rec.actions = append(rec.actions, NewApplyCRDsAction(rec.l))
 	rec.actions = append(rec.actions, NewApplyResourcesAction(rec.l))
 	rec.actions = append(rec.actions, NewConditionsAction(rec.l))
+	rec.actions = append(rec.actions, NewGCAction(rec.l))
 
 	err = rec.init(ctx)
 	if err != nil {

--- a/internal/controller/operator/instance/dapr_instance_controller_action_apply_crds.go
+++ b/internal/controller/operator/instance/dapr_instance_controller_action_apply_crds.go
@@ -59,6 +59,7 @@ func (a *ApplyCRDsAction) Run(ctx context.Context, rc *ReconciliationRequest) er
 			helm.ReleaseGeneration: strconv.FormatInt(rc.Resource.Generation, 10),
 			helm.ReleaseName:       rc.Resource.Name,
 			helm.ReleaseNamespace:  rc.Resource.Namespace,
+			helm.ReleaseVersion:    c.Version(),
 		})
 
 		apply := rc.Resource.Generation != rc.Resource.Status.ObservedGeneration

--- a/internal/controller/operator/instance/dapr_instance_controller_action_gc.go
+++ b/internal/controller/operator/instance/dapr_instance_controller_action_gc.go
@@ -1,0 +1,93 @@
+package instance
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+
+	"github.com/dapr/kubernetes-operator/pkg/controller/gc"
+	"github.com/dapr/kubernetes-operator/pkg/helm"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+
+	"github.com/dapr/kubernetes-operator/pkg/controller/client"
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+)
+
+func NewGCAction(l logr.Logger) Action {
+	return &GCAction{
+		l:  l.WithName("action").WithName("gc"),
+		gc: gc.New(),
+	}
+}
+
+// GCAction cleanup leftover release resources.
+//
+// If the HelmInstance spec changes, all the resources get re-rendered which means some of
+// them may become obsolete (i.e. if some resources are moved from cluster to namespace
+// scope) hence a sort of "garbage collector task" must be executed.
+//
+// The logic of the task it to delete all the resources that have a generation older than
+// current CR one or rendered out of a release version different from the current one. The
+// related values are propagated by the controller to all the rendered resources in as a
+// set of labels (
+//
+// - helm.operator.dapr.io/release.generation
+// - helm.operator.dapr.io/release.version
+//
+// The action MUST be executed as the latest action in the reconciliation loop.
+type GCAction struct {
+	l  logr.Logger
+	gc *gc.GC
+}
+
+func (a *GCAction) Configure(_ context.Context, _ *client.Client, b *builder.Builder) (*builder.Builder, error) {
+	return b, nil
+}
+
+func (a *GCAction) Run(ctx context.Context, rc *ReconciliationRequest) error {
+	c, err := rc.Chart(ctx)
+	if err != nil {
+		return fmt.Errorf("cannot load chart: %w", err)
+	}
+
+	s, err := gcSelector(ctx, rc)
+	if err != nil {
+		return fmt.Errorf("cannot compute gc selector: %w", err)
+	}
+
+	deleted, err := a.gc.Run(ctx, rc.Client, rc.Resource.Namespace, s, func(ctx context.Context, obj unstructured.Unstructured) (bool, error) {
+		if obj.GetLabels() == nil {
+			return false, nil
+		}
+
+		gen := obj.GetLabels()[helm.ReleaseGeneration]
+		ver := obj.GetLabels()[helm.ReleaseVersion]
+
+		if gen == "" || ver == "" {
+			return false, nil
+		}
+
+		if ver != c.Version() {
+			return true, nil
+		}
+
+		g, err := strconv.Atoi(gen)
+		if err != nil {
+			return false, fmt.Errorf("cannot determine release generation: %w", err)
+		}
+
+		return rc.Resource.Generation > int64(g), nil
+	})
+	if err != nil {
+		return fmt.Errorf("cannot run gc: %w", err)
+	}
+
+	a.l.Info("gc", "deleted", deleted)
+
+	return nil
+}
+
+func (a *GCAction) Cleanup(_ context.Context, _ *ReconciliationRequest) error {
+	return nil
+}

--- a/pkg/controller/predicates/dependant.go
+++ b/pkg/controller/predicates/dependant.go
@@ -12,6 +12,29 @@ import (
 
 var _ predicate.Predicate = DependentPredicate{}
 
+type DependentPredicateOption func(*DependentPredicate) *DependentPredicate
+
+func WithWatchDeleted(val bool) DependentPredicateOption {
+	return func(in *DependentPredicate) *DependentPredicate {
+		in.WatchDelete = val
+		return in
+	}
+}
+
+func WithWatchUpdate(val bool) DependentPredicateOption {
+	return func(in *DependentPredicate) *DependentPredicate {
+		in.WatchUpdate = val
+		return in
+	}
+}
+
+func WithWatchStatus(val bool) DependentPredicateOption {
+	return func(in *DependentPredicate) *DependentPredicate {
+		in.WatchStatus = val
+		return in
+	}
+}
+
 type DependentPredicate struct {
 	WatchDelete bool
 	WatchUpdate bool

--- a/pkg/helm/helm.go
+++ b/pkg/helm/helm.go
@@ -9,6 +9,7 @@ const (
 	ReleaseGeneration = "helm.operator.dapr.io/release.generation"
 	ReleaseName       = "helm.operator.dapr.io/release.name"
 	ReleaseNamespace  = "helm.operator.dapr.io/release.namespace"
+	ReleaseVersion    = "helm.operator.dapr.io/release.version"
 
 	ChartsDir = "helm-charts/dapr"
 )

--- a/pkg/resources/resources.go
+++ b/pkg/resources/resources.go
@@ -64,6 +64,16 @@ func Labels(target *unstructured.Unstructured, labels map[string]string) {
 	target.SetLabels(m)
 }
 
+func Label(target *unstructured.Unstructured, key string) string {
+	m := target.GetLabels()
+
+	if m == nil {
+		return ""
+	}
+
+	return m[key]
+}
+
 func Ref(obj client.Object) string {
 	name := obj.GetName()
 	if obj.GetNamespace() == "" {


### PR DESCRIPTION
If the `HelmInstance` spec changes, all the resources get re-rendered which means some of  them may become obsolete (i.e. if some resources are moved from cluster to namespace scope) hence a sort of "garbage collector task" must be executed. 
 
As today, the GC logic would take into account only the resource generation, however, when the operator is updated, the geeneration won't change hence a new algorithm should be implemented to take into account also the release version.


Requires https://github.com/dapr/kubernetes-operator/pull/209